### PR TITLE
Set height of editor according to setup

### DIFF
--- a/src/app/Editor.tsx
+++ b/src/app/Editor.tsx
@@ -12,15 +12,23 @@ import {isDefined} from "./services/utils";
 
 interface EditorProps {initCode?: string; language?: string; appendToChangeLog: (change: EditorChange) => void}
 
-export const Editor = React.forwardRef(({initCode, language, appendToChangeLog}: EditorProps, ref: ForwardedRef<{getCode: () => string | undefined}>) => {
+export interface EditorRefType {
+	getCode: () => string | undefined;
+	setHeight: (height: number) => void;
+}
+
+export const Editor = React.forwardRef(({initCode, language, appendToChangeLog}: EditorProps, ref: ForwardedRef<EditorRefType>) => {
 
 	const [editor, setEditor] = useState<EditorView | null>(null);
 
 	const editorRef = useRef<HTMLPreElement>(null);
 
 	// Expose editor.state.doc.toString() to the parent component
-	useImperativeHandle<{getCode: () => string | undefined}, {getCode: () => string | undefined}>(ref, () => ({
-		getCode: () => editor ? editor.state.doc.toString() : undefined
+	useImperativeHandle<EditorRefType, EditorRefType>(ref, () => ({
+		getCode: () => editor ? editor.state.doc.toString() : undefined,
+		setHeight: (height: number) => {
+			editorRef.current?.style.setProperty("height", `${height}px`)
+		}
 	}), [editor]);
 
 	// Insert editor on initCode change

--- a/src/scss/cs/editor.scss
+++ b/src/scss/cs/editor.scss
@@ -5,7 +5,6 @@
   //font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   //font-size: 0.875rem;
   min-height: 5rem;
-  height: 11.4rem;
   resize: vertical;
 
   .cm-editor {


### PR DESCRIPTION
Allows passing an iFrameHeight prop through the initialise message to set the height of the editor on load.